### PR TITLE
Added compatibility for Spell Action Info

### DIFF
--- a/campaign/record_power.xml
+++ b/campaign/record_power.xml
@@ -2,6 +2,8 @@
 <root>
 	<windowclass name="power_item_header" merge="join">
 		<sheetdata>
+			<button_abjuration name="button_abjuration" insertbefore="actionsmini" />
+
 			<windowlist name="actionsmini">
 				<anchored>
 					<top offset="2" />
@@ -15,8 +17,6 @@
 					<left parent="name" anchor="right" offset="0" />
 				</anchored>
 			</label>
-
-			<button_abjuration name="button_abjuration" />
 		</sheetdata>
 	</windowclass>
 	<windowclass name="power_item" merge="join">

--- a/campaign/scripts/spell_cast.lua
+++ b/campaign/scripts/spell_cast.lua
@@ -13,6 +13,10 @@ function onInit()
     local node = window.getDatabaseNode()
     nLevel = DB.getValue(node, "level", 0)
     setCastToolTip(nLevel)
+
+    if ArcaneWard.hasSAI() then
+        setAnchor("left", "components_text_label", "right", "relative");
+    end
 end
 
 function setCastToolTip(bRitual)

--- a/extension.xml
+++ b/extension.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <root release="3.0" version="3">
-	<announcement text="Arcane Ward v1.1\rby Ryan Hagelstrom 2022" font="emotefont" icon="ArcaneWard"/>
+	<announcement text="Arcane Ward v1.2\rby Ryan Hagelstrom 2022" font="emotefont" icon="ArcaneWard"/>
 	<properties>
-    	<loadorder>141</loadorder>
+    	<loadorder>49</loadorder>
 		<name>Feature: Arcane Ward</name>
-		<version>v1.1s</version>
+		<version>v1.2</version>
 		<author>Ryan Hagelstrom</author>
 		<description>Automates Arcane Ward Trait</description>
 		<ruleset>

--- a/scripts/arcane_ward.lua
+++ b/scripts/arcane_ward.lua
@@ -69,6 +69,10 @@ function hasCA()
     return extensions["ConstitutionalAmendments"]
 end
 
+function hasSAI()
+	return extensions["Spell Action Info"]
+end
+
 function castAbjuration(nodeActor, nLevel ,nName)
 	local rActor = ActorManager.resolveActor(nodeActor)
 	local nActive = DB.getValue(nodeActor, "arcaneward", 0)


### PR DESCRIPTION
- Changed loadorder to be under Spell Action Info for easier implementation of compatibility
- Added detection of Spell Action Info
- Added custom anchoring if both extensions are loaded
- Version bump

Feel free to test with my extension from the Forge or from here https://github.com/ZarestiaDev/Spell-Action-Info/releases/tag/v3.6